### PR TITLE
Add HTTP obfuscation

### DIFF
--- a/v2ray_bridge/config/config.json
+++ b/v2ray_bridge/config/config.json
@@ -54,8 +54,21 @@
         "connectionReuse": true,
         "header": {
           "type": "http",
-          "request": {},
-          "response": {}
+          "request": {
+            "version": "1.1",
+            "method": "GET",
+            "path": ["/"],
+            "headers": {
+              "Host": ["www.softqloud.com", "aws.amazon.com"],
+              "User-Agent": [
+                "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.75 Safari/537.36" ,
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_2 like Mac OS X) AppleWebKit/601.1 (KHTML, like Gecko) CriOS/53.0.2785.109 Mobile/14A456 Safari/601.1.46"
+              ],
+              "Accept-Encoding": ["gzip, deflate"],
+              "Connection": ["keep-alive"],
+              "Pragma": "no-cache"
+            }
+          }
         }
       }
     },

--- a/v2ray_upstream/config/config.json
+++ b/v2ray_upstream/config/config.json
@@ -23,8 +23,27 @@
         "connectionReuse": true,
         "header": {
           "type": "http",
-          "request": {},
-          "response": {}
+          "response": {
+            "version": "1.1",
+            "status": "200",
+            "reason": "OK",
+            "headers": {
+              "Content-Type": [
+                "application/octet-stream",
+                "video/mpeg",
+                "application/x-msdownload",
+                "text/html",
+                "application/x-shockwave-flash"
+              ],
+              "Transfer-Encoding": [
+                "chunked"
+              ],
+              "Connection": [
+                "keep-alive"
+              ],
+              "Pragma": "no-cache"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Thank you for this great resource milad jan.

I use a similar config for HTTP obfuscation. Could you verify if it works with your current configuration first? 


Also, It seems you're exposing both UDP and TCP for inbounds in `docker-compose.yaml`, but the [default network for `shadowsocks`](https://github.com/v2fly/v2fly-github-io/blob/master/docs/config/protocols/shadowsocks.md#inboundconfigurationobject) inbound in is `tcp`, to expose `udp` I think we should explicitly set it in settings. 