### PR TITLE
add udp support to shadowsocks

### DIFF
--- a/v2ray-bridge-server/config/config.json
+++ b/v2ray-bridge-server/config/config.json
@@ -27,7 +27,8 @@
       "settings": {
         "password": "<SHADOWSOCKS-PASSWORD>",
         "method": "aes-128-gcm",
-        "level": 0
+        "level": 0,
+        "network": "tcp,udp"
       }
     },
     {

--- a/v2ray-bridge-server/docker-compose.yml
+++ b/v2ray-bridge-server/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - 127.0.0.1:${HTTP_PORT:-1010}:1010/udp
       - 127.0.0.1:${HTTP_PORT:-1110}:1110
       - ${SHADOWSOCKS_PORT:-1210}:1210
+      - ${SHADOWSOCKS_PORT:-1210}:1210/udp
       - ${VMESS_PORT:-1310}:1310
     volumes:
       - ./config/:/etc/v2ray/


### PR DESCRIPTION
Currently configured shadowsocks protocol is not supporting UDP.
So connected client is not able to have Whatsapp / Telegram calls.

I think this is kind of required for ordinary mobile users.

**I added the following to Bridge-Server:**
- Added udp to inbound shadowsocks server.
- Added port mapping for udp inside docker-compose.yml

thanks for your great work. Saved a lot of time for me.

Zan Zendegi Azadi