### PR TITLE
fix: mistakenly hardcoded upstream uuid field

### DIFF
--- a/v2ray-upstream-server/config/config.json
+++ b/v2ray-upstream-server/config/config.json
@@ -12,7 +12,7 @@
       "settings": {
         "clients": [
           {
-            "id": "2442075d-55c3-48b4-9148-993a82239fea",
+            "id": "<UPSTREAM-UUID>",
             "alterId": 0,
             "security": "none"
           }
@@ -58,3 +58,4 @@
     }
   }
 }
+


### PR DESCRIPTION
Replace hardcoded upstream uuid with  `<UPSTREAM-UUID>` literal string.