### PR TITLE
feat: read alterId from config and support multiple clients in `clients.py`

### DIFF
--- a/v2ray-bridge-server/config/config.json
+++ b/v2ray-bridge-server/config/config.json
@@ -82,11 +82,7 @@
     }
   ],
   "dns": {
-    "servers": [
-      "8.8.8.8",
-      "8.8.4.4",
-      "localhost"
-    ]
+    "servers": ["8.8.8.8", "8.8.4.4", "localhost"]
   },
   "routing": {
     "domainStrategy": "IPIfNonMatch",
@@ -95,9 +91,7 @@
         {
           "type": "field",
           "outboundTag": "freedom",
-          "domain": [
-            "regexp:.*\\.ir$"
-          ]
+          "domain": ["regexp:.*\\.ir$"]
         }
       ]
     }

--- a/v2ray-bridge-server/web/index.html
+++ b/v2ray-bridge-server/web/index.html
@@ -105,8 +105,7 @@
                target="_blank">macOS</a>
         </div>
         <p>نوشته زیر را Copy کنید.</p>
-        <div>
-            <textarea title="Access key" readonly>ss://proxy#name</textarea>
+        <div id="ss-link">
         </div>
         <p>
             برنامه Outline را باز کنید.
@@ -129,8 +128,7 @@
                target="_blank">macOS (V2RayX)</a>
         </div>
         <p>نوشته زیر را Copy کنید.</p>
-        <div>
-            <textarea title="VMESS Link" readonly>vmess://etc</textarea>
+        <div id="vmess-links">
         </div>
         <p>
             در برنامه v2rayNG (Android):


### PR DESCRIPTION
- Print all vmess client links
- Add all vmess client links in web/html
- Read alterId from `config.json` (instead of hardcoded `"0"`)