### PR TITLE
Set default protocol to aes-128-gcm

### DIFF
--- a/v2ray-upstream-server/config/config.json
+++ b/v2ray-upstream-server/config/config.json
@@ -14,7 +14,7 @@
           {
             "id": "<UPSTREAM-UUID>",
             "alterId": 0,
-            "security": "none"
+            "security": "aes-128-gcm"
           }
         ]
       },


### PR DESCRIPTION
By default `security` has been mentioned as `aes-128-gcm` in README.md:
https://github.com/miladrahimi/v2ray-docker-compose/blob/54bc6c5a7b55aaf03e2b6b73a8309cd32f99c084/README.md?plain=1#L80

Either this should change or README, please tell me to change my PR if that needs to be changed too.

Also I think setting a security protocol by default is better than setting `none`, therefore opening this PR.